### PR TITLE
Customized field

### DIFF
--- a/spec/mongoid/orderable_spec.rb
+++ b/spec/mongoid/orderable_spec.rb
@@ -36,6 +36,12 @@ describe Mongoid::Orderable do
     embedded_in :embeds_orderable
   end
 
+  class CustomizedOrderable
+    include Mongoid::Document
+    include Mongoid::Orderable
+
+    orderable :column => :pos
+  end
 
   describe SimpleOrderable do
     before :each do
@@ -249,6 +255,16 @@ describe Mongoid::Orderable do
       positions.should == [[1, 2], [1, 2, 3]]
     end
 
+  end
+
+  describe CustomizedOrderable do
+    it 'does not have default position field' do
+      CustomizedOrderable.fields.should_not have_key('position')
+    end
+
+    it 'should have custom pos field' do
+      CustomizedOrderable.fields.should have_key('pos')
+    end
   end
 
 end


### PR DESCRIPTION
I've noticed that custom position field is not tested at all and that there should be problems with calling `order able` method twice (on inclusion and manually). And I was right. Field and index are defined twice and in this case with different names. I don't need this functionality hence submitting just basic tests so that you're aware :-)
