### PR TITLE
Allow for use with default scopes.

### DIFF
--- a/lib/mongoid/orderable.rb
+++ b/lib/mongoid/orderable.rb
@@ -113,7 +113,7 @@ private
 
   def apply_position target_position
     if persisted? && !embedded? && orderable_scope_changed?
-      self.class.find(_id).remove_from_list
+      self.class.unscoped.find(_id).remove_from_list
       self.orderable_position = nil
     end
 


### PR DESCRIPTION
Since default scopes can limit what's returned by find, documents won't be found if using default scopes.
