### PR TITLE
Support pass-thru of Mongoid field alias (:as parameter)

### DIFF
--- a/lib/mongoid/orderable.rb
+++ b/lib/mongoid/orderable.rb
@@ -13,8 +13,7 @@ module Mongoid::Orderable
       configuration.merge! options if options.is_a?(Hash)
       configuration[:scope] = "#{configuration[:scope]}_id".to_sym if configuration[:scope].is_a?(Symbol) && configuration[:scope].to_s !~ /_id$/
 
-      field_opts = { :type => Integer }.merge(configuration.slice(:as))
-      field configuration[:column], field_opts
+      field configuration[:column], orderable_field_opts(configuration)
       if configuration[:index]
         if MongoidOrderable.mongoid2?
           index configuration[:column]
@@ -48,6 +47,14 @@ module Mongoid::Orderable
 
       before_save :add_to_list
       after_destroy :remove_from_list
+    end
+
+    private
+
+    def orderable_field_opts(configuration)
+      field_opts = { :type => Integer }
+      field_opts.merge!(configuration.slice(:as))
+      field_opts
     end
   end
 

--- a/spec/mongoid/orderable_spec.rb
+++ b/spec/mongoid/orderable_spec.rb
@@ -314,8 +314,10 @@ describe Mongoid::Orderable do
       CustomizedOrderable.fields.should have_key('pos')
     end
 
-    it 'should have an alias my_position which points to pos field' do
-      CustomizedOrderable.database_field_name('my_position').should eq('pos')
+    it 'should have an alias my_position which points to pos field on Mongoid 3+' do
+      if CustomizedOrderable.respond_to?(:database_field_name)
+        CustomizedOrderable.database_field_name('my_position').should eq('pos')
+      end
     end
   end
 


### PR DESCRIPTION
Support pass-thru of Mongoid field alias (`:as` parameter) to underlying Mongoid Orderable field

Example:

```
orderable column: :pos, as: :position
```

This will store the orderable field in the DB as a minified name `pos`, however you can access it in Ruby as `position`
