### PR TITLE
Specify a default rake task.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-script: "bundle exec rake spec"
-
 rvm:
   - 1.9.2
   - 1.9.3

--- a/Rakefile
+++ b/Rakefile
@@ -2,3 +2,5 @@ require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
+
+task :default => [ :spec ]


### PR DESCRIPTION
Avoids having to tell travis what to do and helps lazy developers like me to just type `rake`.
