### PR TITLE
Added support for Mongoid 4.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 script: "bundle exec rake spec"
 
 rvm:
+  - 1.8.7
   - 1.9.2
   - 1.9.3
   - ruby-head
@@ -8,11 +9,18 @@ rvm:
 
 env:
   - MONGOID_VERSION=2
-  - MONGOID_VERSION='~> 3.0.0'
+  - MONGOID_VERSION=3
+  - MONGOID_VERSION=4
 
 matrix:
   exclude:
+    - rvm: 1.8.7
+      env: MONGOID_VERSION=3
+    - rvm: 1.8.7
+      env: MONGOID_VERSION=4
     - rvm: 1.9.2
-      env: MONGOID_VERSION='~> 3.0.0'
+      env: MONGOID_VERSION=3
+    - rvm: 1.9.2
+      env: MONGOID_VERSION=4
 
 services: mongodb

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,13 @@ source "http://rubygems.org"
 # Specify your gem's dependencies in mongoid_orderable.gemspec
 gemspec
 
-case version = ENV['MONGOID_VERSION'] || "~> 3.0.0.rc"
+case version = ENV['MONGOID_VERSION'] || "~> 3.1"
+when /4/
+  gem "mongoid", :github => 'mongoid/mongoid'
+when /3/
+  gem "mongoid", "~> 3.1"
 when /2/
-  gem "mongoid", "~> 2.4.0"
+  gem "mongoid", "~> 2.8"
 else
   gem "mongoid", version
 end

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Mongoid::Orderable is a ordered list implementation for your mongoid models.
 * It uses native mongo batch increment feature
 * It supports assignable api
 * It proper assingns position while moving document between scopes
-* It supports both mongoid 2 and 3
+* It supports mongoid 2, 3 and 4
 
 # How?
 

--- a/lib/mongoid/orderable.rb
+++ b/lib/mongoid/orderable.rb
@@ -111,7 +111,7 @@ module Mongoid::Orderable
   end
 
   def remove_from_list
-    orderable_scoped.where(orderable_column.gt => orderable_position).inc(orderable_column, -1)
+    MongoidOrderable.inc orderable_scoped.where(orderable_column.gt => orderable_position), orderable_column, -1
   end
 
 private
@@ -157,10 +157,10 @@ private
     target_position = target_position_to_position target_position
 
     unless in_list?
-      orderable_scoped.where(orderable_column.gte => target_position).inc(orderable_column, 1)
+      MongoidOrderable.inc orderable_scoped.where(orderable_column.gte => target_position), orderable_column, 1
     else
-      orderable_scoped.where(orderable_column.gte => target_position, orderable_column.lt => orderable_position).inc(orderable_column, 1) if target_position < orderable_position
-      orderable_scoped.where(orderable_column.gt => orderable_position, orderable_column.lte => target_position).inc(orderable_column, -1) if target_position > orderable_position
+      MongoidOrderable.inc(orderable_scoped.where(orderable_column.gte => target_position, orderable_column.lt => orderable_position), orderable_column, 1) if target_position < orderable_position
+      MongoidOrderable.inc(orderable_scoped.where(orderable_column.gt => orderable_position, orderable_column.lte => target_position), orderable_column, -1) if target_position > orderable_position
     end
 
     self.orderable_position = target_position

--- a/lib/mongoid_orderable.rb
+++ b/lib/mongoid_orderable.rb
@@ -1,6 +1,16 @@
 module MongoidOrderable
   def self.mongoid2?
-    Mongoid.const_defined? :Contexts
+    ::Mongoid.const_defined? :Contexts
+  end
+  def self.mongoid3?
+    ::Mongoid.const_defined? :Observer
+  end
+  def self.inc instance, attribute, value
+    if MongoidOrderable.mongoid2? || MongoidOrderable.mongoid3?
+      instance.inc attribute, value
+    else
+      instance.inc(attribute => value)
+    end
   end
 end
 

--- a/lib/mongoid_orderable/mongoid/contexts/enumerable.rb
+++ b/lib/mongoid_orderable/mongoid/contexts/enumerable.rb
@@ -4,7 +4,7 @@ module MongoidOrderable #:nodoc:
       module Enumerable #:nodoc:
         def inc attribute, value
           iterate do |doc|
-            doc.inc(attribute, value)
+            MongoidOrderable.inc doc, attribute, value
           end
         end
       end

--- a/lib/mongoid_orderable/mongoid/contextual/memory.rb
+++ b/lib/mongoid_orderable/mongoid/contextual/memory.rb
@@ -2,9 +2,9 @@ module MongoidOrderable #:nodoc:
   module Mongoid #:nodoc:
     module Contextual #:nodoc:
       module Memory #:nodoc:
-        def inc attribute, value
+        def inc(* args)
           each do |document|
-            document.inc(attribute, value)
+            document.inc *args
           end
         end
       end


### PR DESCRIPTION
Mongoid 4.x has removed `Mongoid::Observer`, so we use that to test for the Mongoid version. There're two changes: `inc` takes a hash and `index_specifications` replaced `index_options`. 

I did a bit of upgrading of default mongoid versions in Gemfile, ran all these:

```
rm Gemfile.lock ; MONGOID_VERSION=2 bundle install ; MONGOID_VERSION=2 bundle exec rspec spec/mongoid/orderable_spec.rb # also with Ruby 1.8.7
rm Gemfile.lock ; MONGOID_VERSION=3 bundle install ; MONGOID_VERSION=3 bundle exec rspec spec/mongoid/orderable_spec.rb
rm Gemfile.lock ; MONGOID_VERSION=4 bundle install ; MONGOID_VERSION=4 bundle exec rspec spec/mongoid/orderable_spec.rb
```
