### PR TITLE
adding lower/higher items methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ item.move_to_top
 item.move_to_bottom
 item.move_higher
 item.move_lower
+
+item.lower_items # return a collection of items lower on the list
+item.higher_items # return a collection of items higher on the list
 ```
 
 # Contributing

--- a/lib/mongoid/orderable.rb
+++ b/lib/mongoid/orderable.rb
@@ -58,6 +58,20 @@ module Mongoid::Orderable
     end
   end
 
+  ##
+  # Returns items below the current document.
+  # Items with a position greater than this document's position.
+  def lower_items
+    orderable_scoped.where(orderable_column.gt => self.position)
+  end
+  
+  ##
+  # Returns items above the current document.
+  # Items with a position lower than this document's position.
+  def higher_items
+    orderable_scoped.where(orderable_column.lt => self.position)
+  end
+
   def move_to! target_position
     @move_to = target_position
     save

--- a/spec/mongoid/orderable_spec.rb
+++ b/spec/mongoid/orderable_spec.rb
@@ -200,6 +200,21 @@ describe Mongoid::Orderable do
         record.reload.position.should == 3
       end
     end
+
+    describe 'utiity methods' do
+
+      it "should return a collection of items lower/higher on the list for lower_items/higher_items" do
+        record_1 = SimpleOrderable.where(:position => 1).first
+        record_2 = SimpleOrderable.where(:position => 2).first
+        record_3 = SimpleOrderable.where(:position => 3).first
+        record_4 = SimpleOrderable.where(:position => 4).first
+        record_5 = SimpleOrderable.where(:position => 5).first
+        expect(record_1.lower_items.to_a).to eq([record_2, record_3, record_4, record_5])
+        expect(record_5.higher_items.to_a).to eq([record_1, record_2, record_3, record_4])
+        expect(record_3.higher_items.to_a).to eq([record_1, record_2])
+        expect(record_3.lower_items.to_a).to eq([record_4, record_5])
+      end
+    end
   end
 
   describe ScopedOrderable do
@@ -319,6 +334,21 @@ describe Mongoid::Orderable do
           positions.should == [1, 2, 3, 1, 2]
           record.reload.position.should == 2
         end
+      end
+    end
+
+    describe 'utiity methods' do
+
+      it "should return a collection of items lower/higher on the list for lower_items/higher_items" do
+        record_1 = SimpleOrderable.where(:position => 1).first
+        record_2 = SimpleOrderable.where(:position => 2).first
+        record_3 = SimpleOrderable.where(:position => 3).first
+        record_4 = SimpleOrderable.where(:position => 4).first
+        record_5 = SimpleOrderable.where(:position => 5).first
+        expect(record_1.lower_items.to_a).to eq([record_2, record_3, record_4, record_5])
+        expect(record_5.higher_items.to_a).to eq([record_1, record_2, record_3, record_4])
+        expect(record_3.higher_items.to_a).to eq([record_1, record_2])
+        expect(record_3.lower_items.to_a).to eq([record_4, record_5])
       end
     end
   end
@@ -490,6 +520,21 @@ describe Mongoid::Orderable do
         record.save
         positions.should == [0, 1, 2, 3, 4]
         record.reload.position.should == 3
+      end
+    end
+
+    describe 'utiity methods' do
+
+      it "should return a collection of items lower/higher on the list for lower_items/higher_items" do
+        record_1 = SimpleOrderable.where(:position => 1).first
+        record_2 = SimpleOrderable.where(:position => 2).first
+        record_3 = SimpleOrderable.where(:position => 3).first
+        record_4 = SimpleOrderable.where(:position => 4).first
+        record_5 = SimpleOrderable.where(:position => 5).first
+        expect(record_1.lower_items.to_a).to eq([record_2, record_3, record_4, record_5])
+        expect(record_5.higher_items.to_a).to eq([record_1, record_2, record_3, record_4])
+        expect(record_3.higher_items.to_a).to eq([record_1, record_2])
+        expect(record_3.lower_items.to_a).to eq([record_4, record_5])
       end
     end
   end


### PR DESCRIPTION
This will add two methods: 

```
item.higher_items # return a collection of items higher on the list
item.lower_items # return a collection of items lower on the list
```

Passing tests have been added and the readme has been updated to describe these two new methods. 
