### PR TITLE
Accounting for change in Mongoid's metadata API.

### DIFF
--- a/lib/mongoid/orderable.rb
+++ b/lib/mongoid/orderable.rb
@@ -64,7 +64,7 @@ module Mongoid::Orderable
   def lower_items
     orderable_scoped.where(orderable_column.gt => self.position)
   end
-  
+
   ##
   # Returns items above the current document.
   # Items with a position lower than this document's position.
@@ -140,7 +140,7 @@ private
 
   def orderable_scoped
     if embedded?
-      send(metadata.inverse).send(metadata.name).orderable_scope(self)
+      send(MongoidOrderable.metadata(self).inverse).send(MongoidOrderable.metadata(self).name).orderable_scope(self)
     else
       (orderable_inherited_class || self.class).orderable_scope(self)
     end

--- a/lib/mongoid_orderable.rb
+++ b/lib/mongoid_orderable.rb
@@ -13,6 +13,14 @@ module MongoidOrderable
       instance.inc(attribute => value)
     end
   end
+
+  def self.metadata instance
+    if MongoidOrderable.mongoid2? || MongoidOrderable.mongoid3?
+      instance.metadata
+    else
+      instance.relation_metadata
+    end
+  end
 end
 
 require 'mongoid'


### PR DESCRIPTION
From Mongoid's changelog:

> > `Document#metadata` has been renamed to `Document#relation_metadata` to
> > avoid common conflicts. Relation proxies also have this renamed to the
> > same as well.

This patch takes the same approach used for the `inc` method.  [All tests pass in CI](https://travis-ci.org/pjkelly/mongoid_orderable) without any changes.
