### PR TITLE
Allowing numeric string to specify a target position.

### DIFF
--- a/lib/config/locales/en.yml
+++ b/lib/config/locales/en.yml
@@ -1,0 +1,9 @@
+en:
+  mongoid:
+    errors:
+      messages:
+        invalid_target_position:
+          message: "`%{value}` is not an acceptable value for target position."
+          summary: "Mongoid::Orderable accepts: a Numeric, a numeric string,
+                    :top, :bottom, or nil."
+          resolution: "You must give an acceptable value for target position."

--- a/lib/mongoid/orderable/callbacks.rb
+++ b/lib/mongoid/orderable/callbacks.rb
@@ -44,11 +44,13 @@ module Mongoid
         def target_position_to_position column, target_position
           target_position = :bottom unless target_position
 
-          target_position = case target_position.to_sym
-                            when :top then orderable_base(column)
-                            when :bottom then bottom_orderable_position(column)
-                            when :higher then orderable_position(column).pred
-                            when :lower then orderable_position(column).next
+          target_position = case target_position.to_s
+                            when 'top' then orderable_base(column)
+                            when 'bottom' then bottom_orderable_position(column)
+                            when 'higher' then orderable_position(column).pred
+                            when 'lower' then orderable_position(column).next
+                            when /\A\d+\Z/ then target_position.to_i
+                            else raise Mongoid::Orderable::Errors::InvalidTargetPosition.new target_position
                             end unless target_position.is_a? Numeric
 
           target_position = orderable_base(column) if target_position < orderable_base(column)

--- a/lib/mongoid/orderable/errors.rb
+++ b/lib/mongoid/orderable/errors.rb
@@ -1,0 +1,2 @@
+require 'mongoid/orderable/errors/mongoid_orderable_error'
+require 'mongoid/orderable/errors/invalid_target_position'

--- a/lib/mongoid/orderable/errors/invalid_target_position.rb
+++ b/lib/mongoid/orderable/errors/invalid_target_position.rb
@@ -1,0 +1,18 @@
+module Mongoid::Orderable
+  module Errors
+    class InvalidTargetPosition < Mongoid::Orderable::Errors::MongoidOrderableError
+      def initialize value
+        super _compose_message(value)
+      end
+
+      private
+      def _compose_message value
+        if MongoidOrderable.mongoid2?
+          translate 'invalid_target_position', { :value => value.inspect }
+        else
+          compose_message 'invalid_target_position', { :value => value.inspect }
+        end
+      end
+    end
+  end
+end

--- a/lib/mongoid/orderable/errors/mongoid_orderable_error.rb
+++ b/lib/mongoid/orderable/errors/mongoid_orderable_error.rb
@@ -1,0 +1,14 @@
+module Mongoid::Orderable
+  module Errors
+    class MongoidOrderableError < ::Mongoid::Errors::MongoidError
+
+      if MongoidOrderable.mongoid2?
+        def translate key, options
+          [:message, :summary, :resolution].map do |section|
+            ::I18n.translate "#{BASE_KEY}.#{key}.#{section}", options
+          end.join ' '
+        end
+      end
+    end
+  end
+end

--- a/lib/mongoid_orderable.rb
+++ b/lib/mongoid_orderable.rb
@@ -1,3 +1,7 @@
+require 'active_support'
+I18n.enforce_available_locales = false
+I18n.load_path << File.join(File.dirname(__FILE__), 'config', 'locales', 'en.yml')
+
 module MongoidOrderable
   def self.mongoid2?
     ::Mongoid.const_defined? :Contexts
@@ -35,6 +39,7 @@ else
 end
 
 require 'mongoid/orderable'
+require 'mongoid/orderable/errors'
 require 'mongoid/orderable/configuration'
 require 'mongoid/orderable/helpers'
 require 'mongoid/orderable/callbacks'

--- a/spec/mongoid/orderable_spec.rb
+++ b/spec/mongoid/orderable_spec.rb
@@ -180,6 +180,18 @@ describe Mongoid::Orderable do
         positions.should == [1, 2, 3, 4, 5, 6]
         newbie.position.should == 4
       end
+
+      it 'middle (with a numeric string)' do
+        newbie = SimpleOrderable.create! :move_to => '4'
+        positions.should == [1, 2, 3, 4, 5, 6]
+        newbie.position.should == 4
+      end
+
+      it 'middle (with a non-numeric string)' do
+        expect do
+          SimpleOrderable.create! :move_to => 'four'
+        end.to raise_error Mongoid::Orderable::Errors::InvalidTargetPosition
+      end
     end
 
     describe 'movement' do
@@ -307,6 +319,18 @@ describe Mongoid::Orderable do
         positions.should == [1, 2, 1, 2, 3, 4]
         newbie.position.should == 2
       end
+
+      it 'middle (with a numeric string)' do
+        newbie = ScopedOrderable.create! :move_to => '2', :group_id => 2
+        positions.should == [1, 2, 1, 2, 3, 4]
+        newbie.position.should == 2
+      end
+
+      it 'middle (with a non-numeric string)' do
+        expect do
+          ScopedOrderable.create! :move_to => 'two', :group_id => 2
+        end.to raise_error Mongoid::Orderable::Errors::InvalidTargetPosition
+      end
     end
 
     describe 'scope movement' do
@@ -338,6 +362,18 @@ describe Mongoid::Orderable do
           positions.should == [1, 2, 3, 1, 2]
           record.reload.position.should == 2
         end
+
+        it 'with point position (with a numeric string)' do
+          record.update_attributes :group_id => 1, :move_to => '2'
+          positions.should == [1, 2, 3, 1, 2]
+          record.reload.position.should == 2
+        end
+
+        it 'with point position (with a non-numeric string)' do
+          expect do
+            record.update_attributes :group_id => 1, :move_to => 'two'
+          end.to raise_error Mongoid::Orderable::Errors::InvalidTargetPosition
+        end
       end
     end
 
@@ -366,6 +402,18 @@ describe Mongoid::Orderable do
           record.update_attributes :group_id => 1, :move_to => 2
           positions.should == [1, 2, 3, 1, 2]
           record.reload.position.should == 2
+        end
+
+        it 'to an existing scope group (with a numeric string)' do
+          record.update_attributes :group_id => 1, :move_to => '2'
+          positions.should == [1, 2, 3, 1, 2]
+          record.reload.position.should == 2
+        end
+
+        it 'to an existing scope group (with a non-numeric string)' do
+          expect do
+            record.update_attributes :group_id => 1, :move_to => 'two'
+          end.to raise_error Mongoid::Orderable::Errors::InvalidTargetPosition
         end
       end
     end
@@ -518,6 +566,18 @@ describe Mongoid::Orderable do
         newbie = ZeroBasedOrderable.create! :move_to => 3
         positions.should == [0, 1, 2, 3, 4, 5]
         newbie.position.should == 3
+      end
+
+      it 'middle (with a numeric string)' do
+        newbie = ZeroBasedOrderable.create! :move_to => '3'
+        positions.should == [0, 1, 2, 3, 4, 5]
+        newbie.position.should == 3
+      end
+
+      it 'middle (with a non-numeric string)' do
+        expect do
+          ZeroBasedOrderable.create! :move_to => 'three'
+        end.to raise_error Mongoid::Orderable::Errors::InvalidTargetPosition
       end
     end
 


### PR DESCRIPTION
Allowing a numeric string for a target position enables updating the position with a request parameter, as following.

``` curl
curl -X PATCH http://example.com/items/1 -d "item[move_to]=3"
```

This change enables updating the position in the common manner of updating resource in Rails or other some frameworks.
