### PR TITLE
Reproduces issue #44.

### DIFF
--- a/spec/mongoid/orderable_spec.rb
+++ b/spec/mongoid/orderable_spec.rb
@@ -201,6 +201,16 @@ describe Mongoid::Orderable do
           SimpleOrderable.create! :move_to => 'four'
         end.to raise_error Mongoid::Orderable::Errors::InvalidTargetPosition
       end
+
+      it 'parallel' do
+        newbie = SimpleOrderable.new
+        newbie.send(:add_to_list)
+        another = SimpleOrderable.create!
+        newbie.save!
+        expect(positions).to eq([1, 2, 3, 4, 5, 6, 7])
+        expect(newbie.position).to eq(7)
+        expect(another.position).to eq(6)
+      end
     end
 
     describe 'movement' do


### PR DESCRIPTION
```
  1) Mongoid::Orderable SimpleOrderable inserting parallel
     Failure/Error: expect(positions).to eq([1, 2, 3, 4, 5, 6, 7])

       expected: [1, 2, 3, 4, 5, 6, 7]
            got: [1, 2, 3, 4, 5, 6, 6]

       (compared using ==)
     # ./spec/mongoid/orderable_spec.rb:217:in `block (4 levels) in <top (required)>'
```
