### PR TITLE
Fix orderable on embedded documents inside an inherited model.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 rvm:
-  - 1.9.3
   - 2.0.0
-  - 2.1
   - 2.2
-  # - rbx
+  - 2.3
 
 env:
   - MONGOID_VERSION=3

--- a/lib/mongoid/orderable/helpers.rb
+++ b/lib/mongoid/orderable/helpers.rb
@@ -16,7 +16,7 @@ module Mongoid
           column ||= default_orderable_column
 
           if embedded?
-            send(MongoidOrderable.metadata(self).inverse).send(MongoidOrderable.metadata(self).name).send("orderable_#{column}_scope", self)
+            _parent.send(MongoidOrderable.metadata(self).name).send("orderable_#{column}_scope", self)
           else
             self.orderable_inherited_class.send("orderable_#{column}_scope", self)
           end


### PR DESCRIPTION
Replace ```send(MongoidOrderable.metadata(self).inverse)``` with mongoid's helper ```_parent```