### PR TITLE
Refactor: Use #max instead of #distinct.max

### DIFF
--- a/lib/mongoid_orderable/mongoid/contextual/memory.rb
+++ b/lib/mongoid_orderable/mongoid/contextual/memory.rb
@@ -2,7 +2,7 @@ module MongoidOrderable #:nodoc:
   module Mongoid #:nodoc:
     module Contextual #:nodoc:
       module Memory #:nodoc:
-        def inc(* args)
+        def inc(*args)
           each do |document|
             document.inc *args
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'bundler'
 Bundler.require
+require 'rspec'
 
 Mongoid.configure do |config|
   config.connect_to 'mongoid_orderable_test'


### PR DESCRIPTION
- Use #max instead of #distinct.max
- Refactor #without_identity_map method for readability (see code)
- Correct whitespace issue "* args" to "*args"
- Add require 'rspec' to spec helper