### PR TITLE
Attempt at fixing out-of-order issues

### DIFF
--- a/lib/mongoid/orderable/listable.rb
+++ b/lib/mongoid/orderable/listable.rb
@@ -40,7 +40,7 @@ module Mongoid
       end
 
       def in_list?(column = nil)
-        !orderable_position(column).nil?
+        persisted? && !orderable_position(column).nil?
       end
     end
   end

--- a/spec/mongoid/orderable_spec.rb
+++ b/spec/mongoid/orderable_spec.rb
@@ -197,6 +197,29 @@ describe Mongoid::Orderable do
           SimpleOrderable.create! move_to: 'four'
         end.to raise_error Mongoid::Orderable::Errors::InvalidTargetPosition
       end
+
+      it 'parallel' do
+        newbie = SimpleOrderable.new
+        newbie.send(:add_to_list)
+        expect(newbie.position).to eq(6)
+        another = SimpleOrderable.create!
+        expect(another.position).to eq(6)
+        newbie.save!
+        expect(positions).to eq([1, 2, 3, 4, 5, 6, 7])
+        expect(newbie.position).to eq(7)
+        expect(another.position).to eq(6)
+      end
+
+      it 'bad data' do
+        if ::Mongoid::Compatibility::Version.mongoid3?
+          SimpleOrderable.all.set(:position, 1)
+        else
+          SimpleOrderable.all.set(position: 1)
+        end
+        expect(positions).to eq([1, 1, 1, 1, 1])
+        newbie = SimpleOrderable.create!
+        expect(positions).to eq([1, 2, 3, 4, 5, 6])
+      end
     end
 
     describe 'movement' do


### PR DESCRIPTION
1) Adds "&& persisted?" to the #in_list? method, which prevents issues when position has been set before an object has been saved for the first time (this is what was happening in @dblock's "parallel" case (#44 / #47)

2) Adds an after save callback which checks all documents for non-sequential members and auto-corrects the data.
  
I've thought about this quite thoroughly and unfortunately I don't think there is any way to guarantee the out-of-position issue won't occur except through a battle-axe approach such as this one.