### PR TITLE
ensure compatibility with Mongoid 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
 
 env:
   - MONGOID_VERSION=HEAD
+  - MONGOID_VERSION=7
   - MONGOID_VERSION=6
   - MONGOID_VERSION=5
   - MONGOID_VERSION=4
@@ -34,6 +35,8 @@ matrix:
   exclude:
     - env: MONGOID_VERSION=HEAD
       rvm: 2.1.10
+    - env: MONGOID_VERSION=7
+      rvm: 2.5.0
     - env: MONGOID_VERSION=6
       rvm: 2.1.10
     - env: MONGOID_VERSION=5

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ services: mongodb
 rvm:
   - 2.1.10
   - 2.3.6
+  - 2.5.0
 
 env:
   - MONGOID_VERSION=HEAD
@@ -36,7 +37,7 @@ matrix:
     - env: MONGOID_VERSION=HEAD
       rvm: 2.1.10
     - env: MONGOID_VERSION=7
-      rvm: 2.5.0
+      rvm: 2.1.10
     - env: MONGOID_VERSION=6
       rvm: 2.1.10
     - env: MONGOID_VERSION=5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 5.1.1 (Next)
 
-* [#57](https://github.com/mongoid/mongoid_orderable/pull/57): Test against Mongoid 7 - [@tomasc](https://github.com/tomasc).
+* [#57](https://github.com/mongoid/mongoid_orderable/pull/57): Ensure compatibility with mongoid 7 - [@tomasc](https://github.com/tomasc).
 * [#52](https://github.com/mongoid/mongoid_orderable/pull/52): Test against Mongoid 6 - [@dblock](https://github.com/dblock).
 
 ### 5.1.0 (2017/06/04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 5.1.1 (Next)
 
+* [#57](https://github.com/mongoid/mongoid_orderable/pull/57): Test against Mongoid 7 - [@tomasc](https://github.com/tomasc).
 * [#52](https://github.com/mongoid/mongoid_orderable/pull/52): Test against Mongoid 6 - [@dblock](https://github.com/dblock).
-* Your contribution here.
 
 ### 5.1.0 (2017/06/04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#57](https://github.com/mongoid/mongoid_orderable/pull/57): Ensure compatibility with mongoid 7 - [@tomasc](https://github.com/tomasc).
 * [#52](https://github.com/mongoid/mongoid_orderable/pull/52): Test against Mongoid 6 - [@dblock](https://github.com/dblock).
+* Your contribution here.
 
 ### 5.1.0 (2017/06/04)
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,11 @@ source 'http://rubygems.org'
 # Specify your gem's dependencies in mongoid_orderable.gemspec
 gemspec
 
-case version = ENV['MONGOID_VERSION'] || '6'
+case version = ENV['MONGOID_VERSION'] || '7'
 when 'HEAD'
   gem 'mongoid', github: 'mongodb/mongoid'
+when /^7/
+  gem 'mongoid', '~> 7.0'
 when /^6/
   gem 'mongoid', '~> 6.0'
 when /^5/

--- a/lib/mongoid_orderable.rb
+++ b/lib/mongoid_orderable.rb
@@ -15,6 +15,14 @@ module MongoidOrderable
     def self.metadata(instance)
       instance.metadata
     end
+  elsif ::Mongoid::Compatibility::Version.mongoid7?
+    def self.inc(instance, attribute, value)
+      instance.inc(attribute => value)
+    end
+
+    def self.metadata(instance)
+      instance._association
+    end
   else
     def self.inc(instance, attribute, value)
       instance.inc(attribute => value)

--- a/spec/mongoid/orderable_spec.rb
+++ b/spec/mongoid/orderable_spec.rb
@@ -20,7 +20,11 @@ describe Mongoid::Orderable do
     include Mongoid::Orderable
 
     field :group_id
-    belongs_to :scoped_group
+    if ::Mongoid::Compatibility::Version.mongoid7?
+      belongs_to :scoped_group, optional: true
+    else
+      belongs_to :scoped_group
+    end
 
     orderable scope: :group
   end
@@ -87,8 +91,14 @@ describe Mongoid::Orderable do
     include Mongoid::Document
     include Mongoid::Orderable
 
-    belongs_to :different_scope, class_name: 'ForeignKeyDiffersOrderable',
-                                 foreign_key: 'different_orderable_id'
+    if ::Mongoid::Compatibility::Version.mongoid7?
+      belongs_to :different_scope, class_name: 'ForeignKeyDiffersOrderable',
+                                   foreign_key: 'different_orderable_id',
+                                   optional: true
+    else
+      belongs_to :different_scope, class_name: 'ForeignKeyDiffersOrderable',
+                                   foreign_key: 'different_orderable_id'
+    end
 
     orderable scope: :different_scope
   end
@@ -99,7 +109,11 @@ describe Mongoid::Orderable do
 
     field :group_id
 
-    belongs_to :scoped_group
+    if ::Mongoid::Compatibility::Version.mongoid7?
+      belongs_to :scoped_group, optional: true
+    else
+      belongs_to :scoped_group
+    end
 
     orderable column: :pos, base: 0, index: false, as: :position
     orderable column: :serial_no, default: true
@@ -110,8 +124,13 @@ describe Mongoid::Orderable do
     include Mongoid::Document
     include Mongoid::Orderable
 
-    belongs_to :apple
-    belongs_to :orange
+    if ::Mongoid::Compatibility::Version.mongoid7?
+      belongs_to :apple, optional: true
+      belongs_to :orange, optional: true
+    else
+      belongs_to :apple
+      belongs_to :orange
+    end
 
     orderable column: :posa, scope: :apple_id
     orderable column: :poso, scope: :orange_id

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ Mongoid.configure do |config|
 end
 
 Mongoid.logger.level = Logger::INFO
-Mongo::Logger.logger.level = Logger::INFO if Mongoid::Compatibility::Version.mongoid5? || Mongoid::Compatibility::Version.mongoid6?
+Mongo::Logger.logger.level = Logger::INFO if Mongoid::Compatibility::Version.mongoid5_or_newer?
 
 Mongoid::Config.belongs_to_required_by_default = false if Mongoid::Compatibility::Version.mongoid6?
 


### PR DESCRIPTION
* updated `.travis.yml` and `Gemfile` to test against Mongoid 7
* updated `mongoid_orderable.rb` for Mongoid 7 style of access to association metadata
* updated `orderable_spec.rb` test classes to have all `belongs_to` associations optional