### PR TITLE
Failing specs for embedded doc position updating

### DIFF
--- a/spec/integration/embedded_spec.rb
+++ b/spec/integration/embedded_spec.rb
@@ -187,6 +187,196 @@ describe EmbeddedOrderable do
         expect(child2.reload.position).to eq(1)
       end
     end
+
+    context '#save! on parent' do
+      let!(:parent) { EmbedsOrderable.last }
+      let!(:child1) { parent.embedded_orderables.first }
+      let!(:child2) { parent.embedded_orderables.second }
+      let!(:child3) { parent.embedded_orderables.third }
+
+      it 'sets existing item to top' do
+        child3.position = 1
+        parent.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [1, 2, 1]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [2, 3, 1]
+      end
+
+      it 'sets existing item above top' do
+        child3.position = 0
+        parent.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [1, 2, 0]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [2, 3, 1]
+      end
+
+      it 'sets existing item to middle' do
+        child3.position = 2
+        parent.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [1, 2, 2]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [1, 3, 2]
+      end
+
+      it 'sets existing item to bottom' do
+        child1.position = 3
+        parent.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [3, 2, 3]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [3, 1, 2]
+      end
+
+      it 'sets existing item below bottom' do
+        child1.position = 4
+        parent.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [4, 2, 3]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [3, 1, 2]
+      end
+
+      it 'sets existing item with nil position' do
+        child2.position = nil
+        parent.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [1, 4, 3]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [1, 3, 2]
+      end
+
+      it 'saves new item with position set to top' do
+        child4 = parent.embedded_orderables.build
+        child4.position = 1
+        parent.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [2, 3, 4, 1]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [2, 3, 4, 1]
+      end
+
+      it 'saves new item with position set above top' do
+        child4 = parent.embedded_orderables.build
+        child4.position = 0
+        parent.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [2, 3, 4, 1]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [2, 3, 4, 1]
+      end
+
+      it 'saves new item with position set to middle' do
+        child4 = parent.embedded_orderables.build
+        child4.position = 2
+        parent.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [1, 3, 4, 2]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [1, 3, 4, 2]
+      end
+
+      it 'saves new item with position set to bottom' do
+        child4 = parent.embedded_orderables.build
+        child4.position = 4
+        parent.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [1, 2, 3, 5]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [1, 2, 3, 4]
+      end
+
+      it 'saves new item with position set below bottom' do
+        child4 = parent.embedded_orderables.build
+        child4.position = 5
+        parent.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [1, 2, 3, 4]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [1, 2, 3, 4]
+      end
+
+      it 'saves new item with nil position' do
+        parent.embedded_orderables.build
+        parent.save!
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [1, 2, 3, 4]
+      end
+    end
+
+    context '#save! on child' do
+      let!(:parent) { EmbedsOrderable.last }
+      let!(:child1) { parent.embedded_orderables.first }
+      let!(:child2) { parent.embedded_orderables.second }
+      let!(:child3) { parent.embedded_orderables.third }
+
+      it 'sets existing item to top' do
+        child3.position = 1
+        child3.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [1, 2, 1]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [2, 3, 1]
+      end
+
+      it 'sets existing item above top' do
+        child3.position = 0
+        child3.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [1, 2, 0]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [2, 3, 1]
+      end
+
+      it 'sets existing item to middle' do
+        child3.position = 2
+        child3.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [1, 2, 2]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [1, 3, 2]
+      end
+
+      it 'sets existing item to bottom' do
+        child1.position = 3
+        child1.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [3, 2, 3]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [3, 1, 2]
+      end
+
+      it 'sets existing item below bottom' do
+        child1.position = 4
+        child1.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [4, 2, 3]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [3, 1, 2]
+      end
+
+      it 'sets existing item with nil position' do
+        child2.position = nil
+        child2.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [1, 4, 3]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [1, 3, 2]
+      end
+
+      it 'saves new item with position set to top' do
+        child4 = parent.embedded_orderables.build
+        child4.position = 1
+        child4.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [2, 3, 4, 1]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [2, 3, 4, 1]
+      end
+
+      it 'saves new item with position set above top' do
+        child4 = parent.embedded_orderables.build
+        child4.position = 0
+        child4.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [2, 3, 4, 1]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [2, 3, 4, 1]
+      end
+
+      it 'saves new item with position set to middle' do
+        child4 = parent.embedded_orderables.build
+        child4.position = 2
+        child4.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [1, 3, 4, 2]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [1, 3, 4, 2]
+      end
+
+      it 'saves new item with position set to bottom' do
+        child4 = parent.embedded_orderables.build
+        child4.position = 4
+        child4.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [1, 2, 3, 5]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [1, 2, 3, 4]
+      end
+
+      it 'saves new item with position set below bottom' do
+        child4 = parent.embedded_orderables.build
+        child4.position = 5
+        child4.save!
+        # expect(parent.embedded_orderables.map(&:position)).to eq [1, 2, 3, 4]
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [1, 2, 3, 4]
+      end
+
+      it 'saves new item with nil position' do
+        child4 = parent.embedded_orderables.build
+        child4.save!
+        expect(parent.reload.embedded_orderables.map(&:position)).to eq [1, 2, 3, 4]
+      end
+    end
   end
 
   context 'with transactions' do


### PR DESCRIPTION
This PR currently demonstrates divergent behavior where the following are not equivalent on embedded docs:

```ruby
# this correctly preserves order
embedded_doc.move_to(2)
embedded_doc.save!

# this does NOT preserve order and just literally sets the position field
embedded_doc.position = 2
embedded_doc.save!
```

This behavior does work correctly on non-embedded docs.

(TBD: perhaps we need an option to preserve legacy direct position setting behavior, but i doubt it...)